### PR TITLE
feat: Implement hybrid search functionality

### DIFF
--- a/src/Controller/ProductFinderController.php
+++ b/src/Controller/ProductFinderController.php
@@ -27,26 +27,117 @@ class ProductFinderController extends AbstractController
     {
         $data = json_decode($request->getContent(), true);
         $query = $data['query'] ?? '';
-        
+        $type = $data['type'] ?? 'hybrid'; // Default to 'hybrid'
+
         if (empty($query)) {
             return $this->json([
                 'success' => false,
                 'message' => 'Query parameter is required',
-                'products' => []
+                // Consistent error response structure based on type
+                ($type === 'vector' ? 'vector_results' : ($type === 'keyword' ? 'keyword_results' : 'products')) => [],
             ], 400);
         }
+
+        $vectorResults = [];
+        $keywordResults = [];
+
+        if ($type === 'vector' || $type === 'hybrid') {
+            $queryEmbedding = $this->embeddingGenerator->generateQueryEmbedding($query);
+            $vectorResults = $this->vectorDBService->searchSimilarProducts($queryEmbedding);
+        }
+
+        if ($type === 'keyword' || $type === 'hybrid') {
+            $keywordResults = $this->vectorDBService->keywordSearch($query);
+        }
         
-        // Generate embedding for the query
-        $queryEmbedding = $this->embeddingGenerator->generateQueryEmbedding($query);
-        
-        // Search for similar products
-        $results = $this->vectorDBService->searchSimilarProducts($queryEmbedding);
-        
-        return $this->json([
-            'success' => true,
-            'query' => $query,
-            'products' => $results
-        ]);
+        if ($type === 'hybrid') {
+            $combinedProducts = $this->combineHybridResults($vectorResults, $keywordResults);
+            return $this->json([
+                'success' => true,
+                'query' => $query,
+                'type' => $type,
+                'products' => $combinedProducts
+            ]);
+        } elseif ($type === 'vector') {
+            return $this->json([
+                'success' => true,
+                'query' => $query,
+                'type' => $type,
+                'vector_results' => $vectorResults
+            ]);
+        } else { // type === 'keyword'
+            return $this->json([
+                'success' => true,
+                'query' => $query,
+                'type' => $type,
+                'keyword_results' => $keywordResults
+            ]);
+        }
+    }
+
+    private function combineHybridResults(array $vectorResults, array $keywordResults): array
+    {
+        $combined = [];
+        $vectorWeight = 0.7;
+        $keywordWeight = 0.3;
+
+        // Process vector results
+        foreach ($vectorResults as $result) {
+            $productId = $result['primary_key'] ?? null;
+            if ($productId === null) continue; // Skip if no ID
+
+            $score = $result['score'] ?? 0; // Assume similarity score (0-1)
+                                            // If distance, it would need inversion e.g. 1 / (1 + distance)
+                                            // As per subtask: "assume it's already a similarity score between 0 and 1"
+
+            $combined[$productId] = [
+                'id' => $productId,
+                'name' => $result['title'] ?? 'N/A', // From vector search result
+                // 'description' => $result['description'] ?? '', // If available
+                'score' => $score * $vectorWeight,
+                'search_type' => 'vector',
+                'original_data' => $result // Keep original vector hit for reference if needed
+            ];
+        }
+
+        // Process keyword results (App\Entity\Product objects)
+        foreach ($keywordResults as $product) {
+            $productId = $product->getId();
+            $keywordBaseScore = 1.0; // Default score for keyword matches
+
+            if (isset($combined[$productId])) {
+                $combined[$productId]['score'] += $keywordBaseScore * $keywordWeight;
+                $combined[$productId]['search_type'] = 'hybrid';
+                // Update name from Product entity if it's more complete/accurate
+                $combined[$productId]['name'] = $product->getName();
+                // Potentially add/update other fields like description
+                // $combined[$productId]['description'] = $product->getDescription();
+            } else {
+                $combined[$productId] = [
+                    'id' => $productId,
+                    'name' => $product->getName(),
+                    // 'description' => $product->getDescription(), // If needed
+                    'score' => $keywordBaseScore * $keywordWeight,
+                    'search_type' => 'keyword',
+                    'original_data' => [ // Construct similar structure as vector for consistency
+                        'primary_key' => $productId,
+                        'title' => $product->getName(),
+                        // 'description' => $product->getDescription(),
+                        // No 'score' from keyword entity itself, so not included here
+                    ]
+                ];
+            }
+        }
+
+        // Convert associative array to indexed array for sorting
+        $sortableCombined = array_values($combined);
+
+        // Sort by score descending
+        usort($sortableCombined, function ($a, $b) {
+            return $b['score'] <=> $a['score'];
+        });
+
+        return $sortableCombined;
     }
 
     #[Route('/api/products/chat', name: 'api_products_chat', methods: ['POST'])]

--- a/tests/Controller/ProductFinderControllerTest.php
+++ b/tests/Controller/ProductFinderControllerTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Entity\Product;
+use App\Service\EmbeddingGeneratorInterface;
+use App\Service\ZillizVectorDBService;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class ProductFinderControllerTest extends WebTestCase
+{
+    private $client;
+    private $vectorDBServiceMock;
+    private $embeddingGeneratorMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client = static::createClient();
+
+        // Create mocks for the services
+        $this->vectorDBServiceMock = $this->createMock(ZillizVectorDBService::class);
+        $this->embeddingGeneratorMock = $this->createMock(EmbeddingGeneratorInterface::class);
+
+        // Configure the embedding generator mock to return a dummy embedding for any query
+        $this->embeddingGeneratorMock->method('generateQueryEmbedding')
+            ->willReturn([0.1, 0.2, 0.3]); // Dummy embedding vector
+
+        // Replace services in the container with our mocks
+        // static::getContainer() is available in WebTestCase
+        static::getContainer()->set(ZillizVectorDBService::class, $this->vectorDBServiceMock);
+        static::getContainer()->set(EmbeddingGeneratorInterface::class, $this->embeddingGeneratorMock);
+    }
+
+    public function testSearchProductsVectorType()
+    {
+        $expectedVectorResults = [
+            ['primary_key' => 1, 'title' => 'Vector Product 1', 'score' => 0.9],
+            ['primary_key' => 2, 'title' => 'Vector Product 2', 'score' => 0.8],
+        ];
+
+        $this->vectorDBServiceMock->expects($this->once())
+            ->method('searchSimilarProducts')
+            ->willReturn($expectedVectorResults);
+        $this->vectorDBServiceMock->expects($this->never())
+            ->method('keywordSearch');
+
+        $this->client->request(
+            'POST',
+            '/api/products/search',
+            [], [], ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['query' => 'test vector query', 'type' => 'vector'])
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertResponseIsSuccessful();
+        $responseData = json_decode($response->getContent(), true);
+
+        $this->assertTrue($responseData['success']);
+        $this->assertEquals('vector', $responseData['type']);
+        $this->assertEquals($expectedVectorResults, $responseData['vector_results']);
+        $this->assertEmpty($responseData['keyword_results']);
+    }
+
+    public function testSearchProductsKeywordType()
+    {
+        // For the 'keyword' type, the controller directly returns the results from
+        // $this->vectorDBService->keywordSearch() under the 'keyword_results' key.
+        // To simplify assertion and avoid deep entity serialization issues in the test,
+        // we'll have the mock return an array of arrays, simulating serialized objects.
+        $expectedKeywordData = [
+            ['id' => 10, 'name' => 'Keyword Product 10', 'description' => 'Desc for 10'],
+            ['id' => 20, 'name' => 'Keyword Product 20', 'description' => 'Desc for 20'],
+        ];
+
+        $this->vectorDBServiceMock->expects($this->once())
+            ->method('keywordSearch')
+            ->willReturn($expectedKeywordData); // Mock returns array of arrays
+        $this->vectorDBServiceMock->expects($this->never())
+            ->method('searchSimilarProducts');
+
+        $this->client->request(
+            'POST',
+            '/api/products/search',
+            [], [], ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['query' => 'test keyword query', 'type' => 'keyword'])
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertResponseIsSuccessful();
+        $responseData = json_decode($response->getContent(), true);
+
+        $this->assertTrue($responseData['success']);
+        $this->assertEquals('keyword', $responseData['type']);
+        $this->assertEquals($expectedKeywordData, $responseData['keyword_results']);
+        $this->assertEmpty($responseData['vector_results']);
+    }
+
+    public function testSearchProductsHybridType()
+    {
+        $vectorResults = [
+            ['primary_key' => 1, 'title' => 'Hybrid Prod 1 from Vector', 'score' => 0.8],
+            ['primary_key' => 3, 'title' => 'Vector Only', 'score' => 0.9],
+        ];
+
+        // For hybrid search, combineHybridResults expects Product entities from keywordSearch
+        $product1Mock = $this->createMock(Product::class);
+        $product1Mock->method('getId')->willReturn(1);
+        $product1Mock->method('getName')->willReturn('Hybrid Prod 1 from Keyword');
+
+        $product2Mock = $this->createMock(Product::class);
+        $product2Mock->method('getId')->willReturn(2);
+        $product2Mock->method('getName')->willReturn('Keyword Only');
+
+        $keywordProductEntities = [$product1Mock, $product2Mock];
+
+        $this->vectorDBServiceMock->method('searchSimilarProducts')->willReturn($vectorResults);
+        $this->vectorDBServiceMock->method('keywordSearch')->willReturn($keywordProductEntities);
+
+        $this->client->request(
+            'POST',
+            '/api/products/search',
+            [], [], ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['query' => 'test hybrid query', 'type' => 'hybrid'])
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertResponseIsSuccessful();
+        $responseData = json_decode($response->getContent(), true);
+
+        $this->assertTrue($responseData['success']);
+        $this->assertEquals('hybrid', $responseData['type']);
+        $this->assertArrayHasKey('products', $responseData);
+
+        $products = $responseData['products'];
+        $this->assertCount(3, $products);
+
+        // Expected scores & order:
+        // 1. Prod 1 (Hybrid): ID 1, Name 'Hybrid Prod 1 from Keyword', Score (0.8*0.7) + (1.0*0.3) = 0.86
+        // 2. Prod 3 (Vector): ID 3, Name 'Vector Only', Score 0.9*0.7 = 0.63
+        // 3. Prod 2 (Keyword): ID 2, Name 'Keyword Only', Score 1.0*0.3 = 0.3
+
+        $this->assertEquals(1, $products[0]['id']);
+        $this->assertEquals('Hybrid Prod 1 from Keyword', $products[0]['name']);
+        $this->assertEqualsWithDelta(0.86, $products[0]['score'], 0.001);
+        $this->assertEquals('hybrid', $products[0]['search_type']);
+
+        $this->assertEquals(3, $products[1]['id']);
+        $this->assertEquals('Vector Only', $products[1]['name']);
+        $this->assertEqualsWithDelta(0.63, $products[1]['score'], 0.001);
+        $this->assertEquals('vector', $products[1]['search_type']);
+
+        $this->assertEquals(2, $products[2]['id']);
+        $this->assertEquals('Keyword Only', $products[2]['name']);
+        $this->assertEqualsWithDelta(0.3, $products[2]['score'], 0.001);
+        $this->assertEquals('keyword', $products[2]['search_type']);
+    }
+
+    public function testSearchProductsEmptyQuery()
+    {
+        $this->client->request(
+            'POST',
+            '/api/products/search',
+            [], [], ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['query' => '']) // Empty query
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+
+        $this->assertFalse($responseData['success']);
+        $this->assertEquals('Query parameter is required', $responseData['message']);
+        // Defaults to 'hybrid' type for error response structure
+        $this->assertArrayHasKey('products', $responseData);
+        $this->assertEmpty($responseData['products']);
+    }
+
+    public function testSearchProductsDefaultsToHybridType()
+    {
+        // Setup similar to hybrid test
+        $vectorResults = [
+            ['primary_key' => 1, 'title' => 'Default Hybrid Vec', 'score' => 0.75],
+        ];
+
+        $product1Mock = $this->createMock(Product::class);
+        $product1Mock->method('getId')->willReturn(1);
+        $product1Mock->method('getName')->willReturn('Default Hybrid Kw');
+        $keywordProductEntities = [$product1Mock];
+
+        $this->vectorDBServiceMock->method('searchSimilarProducts')->willReturn($vectorResults);
+        $this->vectorDBServiceMock->method('keywordSearch')->willReturn($keywordProductEntities);
+
+        $this->client->request(
+            'POST',
+            '/api/products/search',
+            [], [], ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['query' => 'test default hybrid']) // No 'type' parameter
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertResponseIsSuccessful();
+        $responseData = json_decode($response->getContent(), true);
+
+        $this->assertTrue($responseData['success']);
+        $this->assertEquals('hybrid', $responseData['type']); // Check it defaulted to hybrid
+        $this->assertArrayHasKey('products', $responseData);
+        $this->assertCount(1, $responseData['products']);
+
+        // Expected score: (0.75 * 0.7) + (1.0 * 0.3) = 0.525 + 0.3 = 0.825
+        $this->assertEquals(1, $responseData['products'][0]['id']);
+        $this->assertEquals('Default Hybrid Kw', $responseData['products'][0]['name']);
+        $this->assertEqualsWithDelta(0.825, $responseData['products'][0]['score'], 0.001);
+        $this->assertEquals('hybrid', $responseData['products'][0]['search_type']);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->client = null;
+        $this->vectorDBServiceMock = null;
+        $this->embeddingGeneratorMock = null;
+        // Reset any static properties or services if necessary, though kernel reboot usually handles it.
+    }
+}

--- a/tests/Service/ZillizVectorDBServiceTest.php
+++ b/tests/Service/ZillizVectorDBServiceTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\Product;
+use App\Service\ZillizVectorDBService;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Query\Expr;
+use HelgeSverre\Milvus\Milvus as MilvusClient;
+use PHPUnit\Framework\TestCase;
+
+class ZillizVectorDBServiceTest extends TestCase
+{
+    private $milvusClientMock;
+    private $entityManagerMock;
+    private $queryBuilderMock;
+    private $queryMock;
+    private ZillizVectorDBService $service;
+
+    protected function setUp(): void
+    {
+        $this->milvusClientMock = $this->createMock(MilvusClient::class);
+        $this->entityManagerMock = $this->createMock(EntityManagerInterface::class);
+        $this->queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $this->queryMock = $this->createMock(AbstractQuery::class);
+
+        $this->entityManagerMock->method('createQueryBuilder')
+            ->willReturn($this->queryBuilderMock);
+
+        $this->queryBuilderMock->method('select')->willReturnSelf();
+        $this->queryBuilderMock->method('from')->willReturnSelf();
+        $this->queryBuilderMock->method('where')->willReturnSelf();
+        $this->queryBuilderMock->method('setParameter')->willReturnSelf();
+        $this->queryBuilderMock->method('setMaxResults')->willReturnSelf();
+        $this->queryBuilderMock->method('getQuery')->willReturn($this->queryMock);
+
+        // General setup for expr() and orX() for tests that don't override this
+        // Specific tests can use ->expects(...) to override if needed
+        $exprInstanceMock = $this->createMock(Expr::class);
+        $this->queryBuilderMock->method('expr')->willReturn($exprInstanceMock);
+        $orxInstanceMock = $this->createMock(Expr\Orx::class);
+        $exprInstanceMock->method('orX')->willReturn($orxInstanceMock);
+
+
+        $this->service = new ZillizVectorDBService(
+            $this->milvusClientMock,
+            $this->entityManagerMock
+        );
+    }
+
+    public function testKeywordSearchWithOneKeyword()
+    {
+        $keyword = 'test';
+        $limit = 5;
+        $expectedProduct = $this->createMock(Product::class);
+
+        // Local mocks for specific expression expectations in this test
+        $exprMock = $this->createMock(Expr::class);
+        $orxMock = $this->createMock(Expr\Orx::class);
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('select')
+            ->with('p')
+            ->willReturnSelf();
+        $this->queryBuilderMock->expects($this->once())
+            ->method('from')
+            ->with(Product::class, 'p')
+            ->willReturnSelf();
+
+        $this->queryBuilderMock->expects($this->once())->method('expr')->willReturn($exprMock);
+        $exprMock->expects($this->once())->method('orX')->willReturn($orxMock);
+
+        $exprMock->expects($this->exactly(2))
+            ->method('like')
+            ->withConsecutive(
+                ['p.name', ':keyword0'],
+                ['p.description', ':keyword0']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->createMock(Expr\Comparison::class),
+                $this->createMock(Expr\Comparison::class)
+            );
+
+        $orxMock->expects($this->exactly(2))->method('add');
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('where')
+            ->with($orxMock)
+            ->willReturnSelf();
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('setParameter')
+            ->with(':keyword0', '%' . $keyword . '%')
+            ->willReturnSelf();
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('setMaxResults')
+            ->with($limit)
+            ->willReturnSelf();
+
+        $this->queryMock->expects($this->once())
+            ->method('getResult')
+            ->willReturn([$expectedProduct]);
+
+        $results = $this->service->keywordSearch($keyword, $limit);
+
+        $this->assertCount(1, $results);
+        $this->assertSame($expectedProduct, $results[0]);
+    }
+
+    public function testKeywordSearchWithMultipleKeywords()
+    {
+        $query = 'keyword1 keyword2';
+        $keywords = ['keyword1', 'keyword2'];
+        $limit = 3;
+        $expectedProduct1 = $this->createMock(Product::class);
+        $expectedProduct2 = $this->createMock(Product::class);
+
+        // Local mocks for specific expression expectations in this test
+        $exprMock = $this->createMock(Expr::class);
+        $orxMock = $this->createMock(Expr\Orx::class);
+
+        $this->queryBuilderMock->expects($this->once())->method('expr')->willReturn($exprMock);
+        $exprMock->expects($this->once())->method('orX')->willReturn($orxMock);
+
+        $exprMock->expects($this->exactly(4))
+            ->method('like')
+            ->withConsecutive(
+                ['p.name', ':keyword0'],
+                ['p.description', ':keyword0'],
+                ['p.name', ':keyword1'],
+                ['p.description', ':keyword1']
+            )
+            ->willReturn(new Expr\Comparison('a', Expr\Comparison::LIKE, 'b'));
+
+        $orxMock->expects($this->exactly(4))->method('add');
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('where')
+            ->with($orxMock)
+            ->willReturnSelf();
+
+        $this->queryBuilderMock->expects($this->exactly(2))
+            ->method('setParameter')
+            ->withConsecutive(
+                [':keyword0', '%' . $keywords[0] . '%'],
+                [':keyword1', '%' . $keywords[1] . '%']
+            )
+            ->willReturnSelf();
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('setMaxResults')
+            ->with($limit);
+
+        $this->queryMock->expects($this->once())
+            ->method('getResult')
+            ->willReturn([$expectedProduct1, $expectedProduct2]);
+
+        $results = $this->service->keywordSearch($query, $limit);
+
+        $this->assertCount(2, $results);
+    }
+
+    public function testKeywordSearchReturnsNoResults()
+    {
+        $query = 'nonexistent';
+        // Ensure expr() and orX() are called as part of query building
+        $exprMock = $this->createMock(Expr::class);
+        $orxMock = $this->createMock(Expr\Orx::class);
+        $this->queryBuilderMock->method('expr')->willReturn($exprMock); // Use method() if it might be called but not strictly once
+        $exprMock->method('orX')->willReturn($orxMock);
+
+
+        $this->queryMock->expects($this->once())
+            ->method('getResult')
+            ->willReturn([]);
+
+        $results = $this->service->keywordSearch($query);
+        $this->assertEmpty($results);
+    }
+
+    public function testKeywordSearchAppliesLimitCorrectly()
+    {
+        $query = 'search limit test';
+        $customLimit = 7;
+
+        // Ensure expr() and orX() are called as part of query building
+        $exprMock = $this->createMock(Expr::class);
+        $orxMock = $this->createMock(Expr\Orx::class);
+        $this->queryBuilderMock->method('expr')->willReturn($exprMock);
+        $exprMock->method('orX')->willReturn($orxMock);
+
+
+        $this->queryBuilderMock->expects($this->once())
+            ->method('setMaxResults')
+            ->with($customLimit)
+            ->willReturnSelf();
+
+        $this->queryMock->method('getResult')->willReturn([]);
+
+        $this->service->keywordSearch($query, $customLimit);
+    }
+
+    public function testKeywordSearchWithEmptyQueryStringReturnsEmptyArray()
+    {
+        $this->entityManagerMock->expects($this->never())->method('createQueryBuilder');
+
+        $results = $this->service->keywordSearch('');
+        $this->assertEmpty($results);
+
+        $results = $this->service->keywordSearch('   ');
+        $this->assertEmpty($results);
+    }
+}


### PR DESCRIPTION
This commit introduces a hybrid search capability that combines vector search and keyword search for product discovery.

Key changes:
- Added a keyword search method to `ZillizVectorDBService` that queries the relational database for products matching keywords in name or description.
- Updated `ProductFinderController` to support three search types via a `type` request parameter:
    - `vector`: Performs only vector similarity search.
    - `keyword`: Performs only keyword-based search.
    - `hybrid` (default): Combines results from both vector (70% weight) and keyword (30% weight) searches.
- Implemented logic in the controller to combine and rank results for hybrid search:
    - Scores from vector search (similarity) and keyword search (default score of 1.0 for matches) are normalized and weighted.
    - Products found by both methods have their scores combined, and their `search_type` is marked as `hybrid`.
    - Results are de-duplicated based on product ID.
    - The final list of products is sorted by the combined score in descending order.
- The API response for hybrid search now includes a `search_type` field for each product (`vector`, `keyword`, or `hybrid`) to indicate its origin.
- Added unit tests for the new `keywordSearch` method in `ZillizVectorDBService`.
- Added functional tests for `ProductFinderController` to cover all search types, including the logic for combining, weighting, and sorting hybrid search results.