### PR TITLE
feat: Add Gitpod integration with DDEV

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,54 @@
+image: gitpod/workspace-full
+
+tasks:
+  - name: Initialize DDEV
+    init: |
+      echo "Installing DDEV..."
+      curl -fsSL https://raw.githubusercontent.com/ddev/ddev/master/scripts/install_ddev.sh | bash
+      echo "DDEV installation complete."
+      echo "Attempting to source bashrc to make ddev command available..."
+      source ~/.bashrc || echo "Failed to source .bashrc, ddev command might not be immediately available in this script block for 'init'. It should be available for 'command'."
+      # Verify ddev is available for the next step, if not, exit early
+      if ! command -v ddev &> /dev/null; then
+        echo "ddev command could not be found after installation and sourcing .bashrc. Please check PATH or installation."
+        echo "You might need to open a new terminal or restart the workspace."
+        # Attempt to add ddev to PATH directly if sourcing bashrc fails
+        export PATH="$HOME/.ddev/bin:$PATH"
+        if ! command -v ddev &> /dev/null; then
+            echo "Still cannot find ddev. Exiting."
+            exit 1
+        fi
+      fi
+      echo "ddev version:"
+      ddev version
+      echo "Configuring DDEV..."
+      ddev config global --instrumentation-opt-in=false --omit-containers=ddev-ssh-agent
+      # The ddev config command might try to start docker, which might not be fully ready.
+      # We will handle the start in the 'command' block.
+      # We also need to ensure the project is configured to not bind all interfaces,
+      # as Gitpod handles the port forwarding.
+      ddev config --bind-all-interfaces=false --project-tld=gitpod.io
+      echo "DDEV configuration complete."
+    command: |
+      echo "Starting DDEV..."
+      # Ensure Docker is running before starting DDEV
+      sudo systemctl start docker --quiet || echo "Docker already running or failed to start via systemctl."
+      ddev start -y
+      echo "DDEV started."
+      echo "Application should be available at: $(ddev describe -j | jq -r '.raw.urls.web[0]')"
+
+ports:
+  - port: 80
+    onOpen: open-preview
+  - port: 443
+    onOpen: ignore
+  # Add other necessary ports if DDEV config reveals them (e.g. Mailpit, database)
+  - port: 8025 # Mailpit HTTP
+    onOpen: open-browser
+  - port: 8026 # Mailpit HTTPS
+    onOpen: ignore
+  - port: 3306 # MariaDB - adjust if different db is used, usually not exposed directly to browser
+
+vscode:
+  extensions:
+    - ddev.ddev-vscode-extension

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Die Anwendung besteht aus folgenden Hauptkomponenten:
    ddev start
    ```
 
+### Entwicklung mit Gitpod
+
+Dieses Projekt kann direkt in Gitpod geöffnet und verwendet werden, einer Online-IDE für GitHub.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/iGore/symfony-product-finder)
+
+Gitpod startet automatisch eine voll funktionsfähige Entwicklungsumgebung, einschließlich der DDEV-Integration. Nach dem Start des Workspaces wird DDEV automatisch gestartet, und die Anwendung ist über die von Gitpod bereitgestellte URL zugänglich. Die notwendigen Ports (z.B. für den Webserver und Mailpit) werden automatisch geöffnet.
+
+Sie können DDEV-Befehle wie gewohnt im Gitpod-Terminal verwenden (z.B. `ddev ssh`, `ddev logs`).
+
 ## Verwendung
 
 ### Produkte importieren


### PR DESCRIPTION
This commit introduces Gitpod integration to the project, automatically starting a DDEV environment when a workspace is launched.

The following changes were made:
- Added a `.gitpod.yml` file to configure the Gitpod workspace.
- The Gitpod configuration includes tasks to:
    - Install the latest version of DDEV.
    - Configure DDEV globally (disable instrumentation, omit ssh-agent).
    - Configure the DDEV project (set TLD to gitpod.io, disable bind-all-interfaces).
    - Start the DDEV services.
- Exposed necessary ports (80 for web, 8025 for Mailpit) for access via Gitpod's preview.
- Added the DDEV VSCode extension to the Gitpod workspace configuration for better developer experience.

To test this integration:
1. Open the repository in Gitpod (e.g., gitpod.io#your-repo-url).
2. Wait for the workspace to build and DDEV to start.
3. The application should become available in a preview tab, and Mailpit on its respective port.
4. DDEV commands can be used in the Gitpod terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated Gitpod workspace configuration for streamlined development, including DDEV setup, service initialization, and port forwarding.
  - Integrated recommended VSCode extension for enhanced development experience within Gitpod.
  - Updated PHP version to 8.3 in the development environment configuration.
  - Removed Symfony CI GitHub Actions workflow.
  - Updated project dependencies, adding Milvus, removing Symfony Translation, and upgrading PHPUnit to version 12.1.
  - Improved PHPUnit configuration to better handle deprecation warnings.
- **Documentation**
  - Added Gitpod usage instructions to the README for cloud-based development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->