### PR TITLE
feat: Add GitHub Actions CI pipeline for Symfony

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Symfony CI
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1' # As per composer.json
+          extensions: ctype, iconv, simplexml # As per composer.json
+          coverage: none # Disable Xdebug for faster execution
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Run tests
+        run: bin/phpunit


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to perform continuous integration checks on pull requests for the Symfony application.

The CI pipeline includes the following steps:
- Checks out the code.
- Sets up PHP 8.1 with required extensions (ctype, iconv, simplexml).
- Caches Composer dependencies to speed up builds.
- Installs Composer dependencies.
- Runs PHPUnit tests using the `bin/phpunit` script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated Symfony CI workflow to run tests and check dependencies on pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->