### PR TITLE
Simplifies chat search functionality

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - bin/
         - config/

--- a/src/Command/ImportProductsCommand.php
+++ b/src/Command/ImportProductsCommand.php
@@ -2,7 +2,6 @@
 
 namespace App\Command;
 
-use App\Entity\Product;
 use App\Service\EmbeddingGeneratorInterface;
 use App\Service\XmlImportService;
 use App\Service\VectorStoreInterface;

--- a/src/Controller/ProductFinderController.php
+++ b/src/Controller/ProductFinderController.php
@@ -53,8 +53,7 @@ class ProductFinderController extends AbstractController
     #[Route('/api/products/chat', name: 'api_products_chat', methods: ['POST'])]
     public function chatSearch(#[MapRequestPayload] ChatRequestDto $chatRequest): JsonResponse
     {
-        $message = $chatRequest->getMessage();
-        $history = $chatRequest->getHistory();
+        $message = $chatRequest->message;
 
         if (empty($message)) {
             $response = new ChatResponseDto(
@@ -67,8 +66,8 @@ class ProductFinderController extends AbstractController
             return $this->json($response, 400);
         }
 
-        // Pass history to intent extraction
-        $searchQuery = $this->extractSearchIntent($message, $history);
+        // Use message directly as search query
+        $searchQuery = $message;
 
         try {
             // Generate embedding for the query
@@ -82,7 +81,7 @@ class ProductFinderController extends AbstractController
             }
 
             // Filter results to only include products with distance <= 0.5
-            $filteredResults = array_filter($results, function($result) {
+            $filteredResults = array_filter($results, static function($result) {
                 return isset($result['distance']) && $result['distance'] <= 0.5;
             });
 
@@ -117,7 +116,7 @@ class ProductFinderController extends AbstractController
             $recommendation = $this->searchService->generateChatCompletion($messages);
 
             // Convert results to ProductResponseDto objects
-            $productDtos = array_map(function($result) {
+            $productDtos = array_map(static function($result) {
                 return ProductResponseDto::fromArray($result);
             }, $filteredResults);
 
@@ -142,14 +141,5 @@ class ProductFinderController extends AbstractController
         }
     }
 
-    /**
-     * Extract search intent from a chat message
-     */
-    private function extractSearchIntent(string $message, array $history = []): string
-    {
-        // Example: Use the last user message as search query
-        // You could also implement more complex logic/NLP here
-        return $message;
-    }
 
 }

--- a/src/DTO/Request/ChatRequestDto.php
+++ b/src/DTO/Request/ChatRequestDto.php
@@ -4,38 +4,18 @@ namespace App\DTO\Request;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-class ChatRequestDto
+readonly class ChatRequestDto
 {
     #[Assert\NotBlank(message: "Message parameter is required")]
     #[Assert\Type("string")]
-    private string $message;
+    public string $message;
 
-    #[Assert\Type("array")]
-    private array $history;
-
-    public function __construct(string $message = '', array $history = [])
-    {
-        $this->message = $message;
-        $this->history = $history;
-    }
-
-    public function getMessage(): string
-    {
-        return $this->message;
-    }
-
-    public function setMessage(string $message): void
+    /**
+     * @param string $message
+     */
+    public function __construct(string $message = '')
     {
         $this->message = $message;
     }
 
-    public function getHistory(): array
-    {
-        return $this->history;
-    }
-
-    public function setHistory(array $history): void
-    {
-        $this->history = $history;
-    }
 }

--- a/src/DTO/Response/ChatResponseDto.php
+++ b/src/DTO/Response/ChatResponseDto.php
@@ -2,14 +2,18 @@
 
 namespace App\DTO\Response;
 
-class ChatResponseDto implements \JsonSerializable
+readonly class ChatResponseDto implements \JsonSerializable
 {
-    private bool $success;
-    private ?string $query = null;
-    private ?string $message = null;
-    private ?string $response = null;
-    private array $products = [];
+    public bool $success;
+    public ?string $query;
+    public ?string $message;
+    public ?string $response;
+    /** @var ProductResponseDto[] */
+    public array $products;
 
+    /**
+     * @param ProductResponseDto[] $products
+     */
     public function __construct(
         bool $success = true,
         ?string $query = null,
@@ -24,72 +28,10 @@ class ChatResponseDto implements \JsonSerializable
         $this->products = $products;
     }
 
-    public function isSuccess(): bool
-    {
-        return $this->success;
-    }
-
-    public function setSuccess(bool $success): void
-    {
-        $this->success = $success;
-    }
-
-    public function getQuery(): ?string
-    {
-        return $this->query;
-    }
-
-    public function setQuery(?string $query): void
-    {
-        $this->query = $query;
-    }
-
-    public function getMessage(): ?string
-    {
-        return $this->message;
-    }
-
-    public function setMessage(?string $message): void
-    {
-        $this->message = $message;
-    }
-
-    public function getResponse(): ?string
-    {
-        return $this->response;
-    }
-
-    public function setResponse(?string $response): void
-    {
-        $this->response = $response;
-    }
-
-    /**
-     * @return ProductResponseDto[]
-     */
-    public function getProducts(): array
-    {
-        return $this->products;
-    }
-
-    /**
-     * @param ProductResponseDto[] $products
-     */
-    public function setProducts(array $products): void
-    {
-        $this->products = $products;
-    }
-
-    /**
-     * Add a product to the response
-     */
-    public function addProduct(ProductResponseDto $product): void
-    {
-        $this->products[] = $product;
-    }
-
     /**
      * Convert the DTO to an array for JSON serialization
+     *
+     * @return array<string, mixed>
      */
     public function jsonSerialize(): array
     {

--- a/src/DTO/Response/ProductResponseDto.php
+++ b/src/DTO/Response/ProductResponseDto.php
@@ -4,9 +4,9 @@ namespace App\DTO\Response;
 
 class ProductResponseDto implements \JsonSerializable
 {
-    private ?string $id = null;
-    private ?string $title = null;
-    private ?float $distance = null;
+    public readonly ?string $id;
+    public readonly ?string $title;
+    public readonly ?float $distance;
 
     public function __construct(?string $id = null, ?string $title = null, ?float $distance = null)
     {
@@ -15,38 +15,10 @@ class ProductResponseDto implements \JsonSerializable
         $this->distance = $distance;
     }
 
-    public function getId(): ?string
-    {
-        return $this->id;
-    }
-
-    public function setId(?string $id): void
-    {
-        $this->id = $id;
-    }
-
-    public function getTitle(): ?string
-    {
-        return $this->title;
-    }
-
-    public function setTitle(?string $title): void
-    {
-        $this->title = $title;
-    }
-
-    public function getDistance(): ?float
-    {
-        return $this->distance;
-    }
-
-    public function setDistance(?float $distance): void
-    {
-        $this->distance = $distance;
-    }
-
     /**
      * Create a ProductResponseDto from an array
+     * 
+     * @param array<string, mixed> $data
      */
     public static function fromArray(array $data): self
     {
@@ -59,6 +31,8 @@ class ProductResponseDto implements \JsonSerializable
 
     /**
      * Convert the DTO to an array for JSON serialization
+     * 
+     * @return array<string, mixed>
      */
     public function jsonSerialize(): array
     {

--- a/src/Service/EmbeddingGeneratorInterface.php
+++ b/src/Service/EmbeddingGeneratorInterface.php
@@ -10,15 +10,15 @@ interface EmbeddingGeneratorInterface
      * Generate embeddings for a product
      * 
      * @param Product $product
-     * @return array The embedding vector
+     * @return array<int, float> The embedding vector
      */
     public function generateEmbedding(Product $product): array;
-    
+
     /**
      * Generate embeddings for a search query
      * 
      * @param string $query
-     * @return array The embedding vector
+     * @return array<int, float> The embedding vector
      */
     public function generateQueryEmbedding(string $query): array;
 }

--- a/src/Service/OpenAISearchService.php
+++ b/src/Service/OpenAISearchService.php
@@ -48,8 +48,8 @@ class OpenAISearchService implements SearchServiceInterface
     /**
      * Generate a chat completion for the given messages
      * 
-     * @param array $messages Array of message objects with 'role' and 'content' keys
-     * @param array $options Additional options for the API call (temperature, max_tokens, etc.)
+     * @param array<array{role: string, content: string}> $messages Array of message objects with 'role' and 'content' keys
+     * @param array<string, mixed> $options Additional options for the API call (temperature, max_tokens, etc.)
      * @return string The generated text response
      * @throws \RuntimeException If the API response format is invalid or if the API call fails
      */
@@ -94,7 +94,7 @@ class OpenAISearchService implements SearchServiceInterface
      * Generate a simple text completion for a single prompt
      * 
      * @param string $prompt The text prompt
-     * @param array $options Additional options for the API call
+     * @param array<string, mixed> $options Additional options for the API call
      * @return string The generated text response
      */
     public function generateCompletion(string $prompt, array $options = []): string

--- a/src/Service/PromptService.php
+++ b/src/Service/PromptService.php
@@ -10,6 +10,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class PromptService implements PromptServiceInterface
 {
+    /** @var array<string, array<string, string>> */
     private array $prompts;
 
     /**
@@ -43,7 +44,7 @@ class PromptService implements PromptServiceInterface
      * 
      * @param string $section The section in the YAML file
      * @param string $key The key of the prompt
-     * @param array $parameters Parameters to replace in the prompt
+     * @param array<string, string> $parameters Parameters to replace in the prompt
      * @return string The prompt with parameters replaced
      * @throws \InvalidArgumentException If the prompt key is not found
      */

--- a/src/Service/PromptServiceInterface.php
+++ b/src/Service/PromptServiceInterface.php
@@ -12,7 +12,7 @@ interface PromptServiceInterface
      * 
      * @param string $section The section in the YAML file
      * @param string $key The key of the prompt
-     * @param array $parameters Parameters to replace in the prompt
+     * @param array<string, string> $parameters Parameters to replace in the prompt
      * @return string The prompt with parameters replaced
      * @throws \InvalidArgumentException If the prompt key is not found
      */

--- a/src/Service/SearchServiceInterface.php
+++ b/src/Service/SearchServiceInterface.php
@@ -13,8 +13,8 @@ interface SearchServiceInterface
     /**
      * Generate a chat completion for the given messages
      * 
-     * @param array $messages Array of message objects with 'role' and 'content' keys
-     * @param array $options Additional options for the API call (temperature, max_tokens, etc.)
+     * @param array<array{role: string, content: string}> $messages Array of message objects with 'role' and 'content' keys
+     * @param array<string, mixed> $options Additional options for the API call (temperature, max_tokens, etc.)
      * @return string The generated text response
      * @throws \RuntimeException If the API response format is invalid or if the API call fails
      */
@@ -24,7 +24,7 @@ interface SearchServiceInterface
      * Generate a simple text completion for a single prompt
      * 
      * @param string $prompt The text prompt
-     * @param array $options Additional options for the API call
+     * @param array<string, mixed> $options Additional options for the API call
      * @return string The generated text response
      */
     public function generateCompletion(string $prompt, array $options = []): string;


### PR DESCRIPTION
Refactors the chat search endpoint to streamline the search process.

Removes intent extraction logic and directly uses the user's message as the search query. Updates DTOs to be readonly.
Increases PHPStan level to 6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and made several data transfer objects (DTOs) immutable, removing unnecessary getters, setters, and properties.
  - Streamlined request and response handling for chat-based product search.
  - Reduced code complexity by eliminating redundant methods and indirection.

- **Style**
  - Improved type annotations and documentation for service interfaces and methods to clarify expected data structures.

- **Tests**
  - Updated test mocks and type hints for more precise and scenario-specific behavior in product import tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->